### PR TITLE
Use reference instead of account number

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,7 @@
 env:
     node: true
     mocha: true
+    es6: true
 extends: 'eslint:recommended'
 parserOptions:
     sourceType:
@@ -26,6 +27,7 @@ rules:
     semi:
         - error
         - always
+    no-undef: warn
     no-unused-vars:
         - 0
         - args: none

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ISA Transfer Authority Network
 
-This is a transparent B2B network joinable by ISA providers (UK) and, potentially, regulators to quickly run investigations.
+This is a *permissioned* blockchain network joinable by ISA providers (UK) and, potentially, regulators to quickly run investigations.
 
 A meticulous ACL defines what resource are accessible, with what permission(s) and by which peers exaclty.
 
@@ -14,7 +14,7 @@ A meticulous ACL defines what resource are accessible, with what permission(s) a
 
 ## Prerequisites
 
-[Hyperledger Composer](https://hyperledger.github.io/composer/installing/development-tools.html) is up and running.
+[Hyperledger Composer](https://hyperledger.github.io/composer/) is up and running.
 
 Please note that this is a project built on top of [Hyperledger Fabric v1.0](https://www.hyperledger.org/projects/fabric).
 
@@ -37,7 +37,8 @@ Import the generated *banana* file into the [Hyperledger local playground](https
 ## Why this complicated stuff
 
 - I ~~like~~ love Hyperledged Fabric distributed ledger technology
-- Blockchain is not just about mining Bitcoin
+- Blockchain is not just about mining Bitcoin ($$$)
+- Ethereum is permissionless (*open* != *safe*)
 - [ISA transfer procedure looks so 90s](https://www.gov.uk/individual-savings-accounts/transferring-your-isa)
 
 ## Tests
@@ -48,21 +49,21 @@ Written using [mocha](https://github.com/mochajs/mocha), to be refactored asap.
   #b2b.isa.transfers
     validateRequest()
       when there is no ISA account matching the request
-        ✓ rejects the requests (72ms)
+        ✓ rejects the request (89ms)
       when there is a valid ISA account matching the request
         when the fiscal year is not matching the one in the request
-          ✓ rejects the requests (65ms)
+          ✓ rejects the request (72ms)
         when there is not sufficient balance to transfer out
-          ✓ rejects the requests (61ms)
+          ✓ rejects the request (76ms)
         when the request is valid
-          ✓ accepts the requests (63ms)
+          ✓ accepts the requests (67ms)
     sendMoney()
-      ✓ moves the balance out of the existing ISA and updates the transfer request (59ms)
+      ✓ moves the balance out of the existing ISA and updates the transfer request (58ms)
     distributeMoney()
-      ✓ adds the the balance to a new destination ISA and updates the transfer request (83ms)
+      ✓ adds the the balance to a new destination ISA and updates the transfer request (65ms)
 
 
-  6 passing (6s)
+  6 passing (2s)
 ```
 
 ## License: Apache 2.0

--- a/lib/isaTransfer.js
+++ b/lib/isaTransfer.js
@@ -33,8 +33,8 @@ function validateRequest(tx) {
         throw new Error('Something is horribly wrong with some amounts in the request');
     }
 
-    return query('findISABySortCodeAndAccountNumber',
-        { sortCode: transferRequest.sortCode, accountNumber: transferRequest.accountNumber }).then(function(isas) {
+    return query('findISABySortCodeAndAccountReference',
+        { sortCode: transferRequest.sortCode, accountReference: transferRequest.accountReference }).then(function(isas) {
         var isa = isas[0];
         var rejectReason;
 

--- a/models/b2b.isa.transfers.cto
+++ b/models/b2b.isa.transfers.cto
@@ -11,8 +11,8 @@ participant Provider identified by name {
 
 asset ISA identified by id {
   o String id
-  o String sortCode regex=/[0-9]{6}/
-  o String accountNumber regex=/[0-9]{7,9}/
+  o String sortCode regex=/[0-9]{6}/ optional
+  o String accountReference // it could be the account number.
   o String type regex=/Cash|Stock&Shares/
   o Integer fiscalYear
   o Double balance
@@ -21,8 +21,8 @@ asset ISA identified by id {
 
 asset TransferRequest identified by id {
   o String id
-  o String sortCode regex=/[0-9]{6}/
-  o String accountNumber regex=/[0-9]{7,9}/
+  o String sortCode regex=/[0-9]{6}/ optional
+  o String accountReference
   o String type default='Cash' regex=/Cash|Stock&Shares/
   o Integer fiscalYear
   o Double amountRequested

--- a/package-lock.json
+++ b/package-lock.json
@@ -725,30 +725,82 @@
       }
     },
     "composer-admin": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/composer-admin/-/composer-admin-0.16.2.tgz",
-      "integrity": "sha512-ZuVHLrEdjy6mC7lpZzNmx6sec2bcVHfG5u5wy9ftGOTjZBYh3Wf2kwXf55rsq50abye2nKAGSHWAmlgW3c/dEw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/composer-admin/-/composer-admin-0.16.3.tgz",
+      "integrity": "sha512-TAJTHpfBSylODL3Tf5QeESlaMOd9LQEItSln6rdccFR702uDv0rt2BEHwAZOmiv4Xomuf2Ko3F4YWnfC/p3aMw==",
       "dev": true,
       "requires": {
-        "composer-common": "0.16.2",
-        "composer-connector-hlfv1": "0.16.2"
+        "composer-common": "0.16.3",
+        "composer-connector-hlfv1": "0.16.3"
+      },
+      "dependencies": {
+        "composer-connector-hlfv1": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/composer-connector-hlfv1/-/composer-connector-hlfv1-0.16.3.tgz",
+          "integrity": "sha512-/l6zT90bDE3+fmxAQmp2Q2lIQDbcsyx/q+3bXd86iarbM7Wh6bPXYMRgqmjwqLT1bVEfApfF1o3c43bDGzHjxw==",
+          "dev": true,
+          "requires": {
+            "composer-common": "0.16.3",
+            "composer-runtime-hlfv1": "0.16.3",
+            "fabric-ca-client": "1.0.2",
+            "fabric-client": "1.0.2",
+            "fs-extra": "1.0.0",
+            "grpc": "1.6.6",
+            "semver": "5.3.0",
+            "temp": "0.8.3",
+            "thenify-all": "1.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "composer-runtime-hlfv1": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/composer-runtime-hlfv1/-/composer-runtime-hlfv1-0.16.3.tgz",
+          "integrity": "sha512-TO04X4y59yP1ZKn4fk9EVV8fnyOOhyDePHuPFakzY1XXawTVSl/RyPUU6zB8QJpx/BbMul2/cIj8evG065fJLw==",
+          "dev": true
+        }
       }
     },
     "composer-client": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/composer-client/-/composer-client-0.16.2.tgz",
-      "integrity": "sha512-6uvxYk+M16G6OcRykhhiJ4XbkqNeQTfF8EO4KMyBP3lDerZJwH7B1qFD4JmUqa4JTTeoAwjHpw8AEfQxybiQSA==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/composer-client/-/composer-client-0.16.3.tgz",
+      "integrity": "sha512-7YX5Lvi3qtqpQLUBiBkL9vb4XiBnQPZ8LBY3oRC67lf3VUVYpj5BGr3CNByVHZHCGaTWEPMR/osEPzasS43Y+g==",
       "dev": true,
       "requires": {
-        "composer-common": "0.16.2",
-        "composer-connector-hlfv1": "0.16.2",
+        "composer-common": "0.16.3",
+        "composer-connector-hlfv1": "0.16.3",
         "uuid": "3.0.1"
+      },
+      "dependencies": {
+        "composer-connector-hlfv1": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/composer-connector-hlfv1/-/composer-connector-hlfv1-0.16.3.tgz",
+          "integrity": "sha512-/l6zT90bDE3+fmxAQmp2Q2lIQDbcsyx/q+3bXd86iarbM7Wh6bPXYMRgqmjwqLT1bVEfApfF1o3c43bDGzHjxw==",
+          "dev": true,
+          "requires": {
+            "composer-common": "0.16.3",
+            "composer-runtime-hlfv1": "0.16.3",
+            "fabric-ca-client": "1.0.2",
+            "fabric-client": "1.0.2",
+            "fs-extra": "1.0.0",
+            "grpc": "1.6.6",
+            "semver": "5.3.0",
+            "temp": "0.8.3",
+            "thenify-all": "1.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "composer-runtime-hlfv1": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/composer-runtime-hlfv1/-/composer-runtime-hlfv1-0.16.3.tgz",
+          "integrity": "sha512-TO04X4y59yP1ZKn4fk9EVV8fnyOOhyDePHuPFakzY1XXawTVSl/RyPUU6zB8QJpx/BbMul2/cIj8evG065fJLw==",
+          "dev": true
+        }
       }
     },
     "composer-common": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.16.2.tgz",
-      "integrity": "sha512-qryn6aDvq1iAxgQq+QVA8p617RyCM8tWVv2NLxrpVnlHTR9N09psErYsaksudEbtG4hSL5l0lS+gTNVpqXGV7A==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/composer-common/-/composer-common-0.16.3.tgz",
+      "integrity": "sha512-YqGiSnOU7TWS4ilHCC/kvbHGUIFKTvpRmfTJxV0Ol1ZraMHZSVlQqUZ0J48UfyL0d7fKj7hCO0D5IyokQEEZxQ==",
       "dev": true,
       "requires": {
         "acorn": "5.1.2",
@@ -781,119 +833,63 @@
       }
     },
     "composer-connector-embedded": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/composer-connector-embedded/-/composer-connector-embedded-0.16.2.tgz",
-      "integrity": "sha512-ccnthJ46ODANokEPM449T0IrhRaAezJBe2KqX6rfs3KyYncvxwlmkPOXykOvFzwtY07+ItL1nA+hfMqwsQaFAQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/composer-connector-embedded/-/composer-connector-embedded-0.16.3.tgz",
+      "integrity": "sha512-vusd3/gFHSV1VlCgOi5+1gpDnQvw0Br2NBm807dZEgLVHJKFTB3oa/sf8P/Lt+7h+3GwNYYWTekjn99UbsNXhw==",
       "dev": true,
       "requires": {
-        "composer-common": "0.16.2",
-        "composer-runtime": "0.16.2",
-        "composer-runtime-embedded": "0.16.2"
-      }
-    },
-    "composer-connector-hlfv1": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/composer-connector-hlfv1/-/composer-connector-hlfv1-0.16.2.tgz",
-      "integrity": "sha512-/rCrMoDek4nUqnCJp7zPcWBe7e2V2czF7U2wvWdRh6InEZNknUdaOpHgO8qbooZRhJodsxpK1EGDRYOKhuVsrQ==",
-      "dev": true,
-      "requires": {
-        "composer-common": "0.16.2",
-        "composer-runtime-hlfv1": "0.16.2",
-        "fabric-ca-client": "1.0.2",
-        "fabric-client": "1.0.2",
-        "fs-extra": "1.0.0",
-        "grpc": "1.6.6",
-        "semver": "5.3.0",
-        "temp": "0.8.3",
-        "thenify-all": "1.6.0",
-        "uuid": "3.0.1"
-      }
-    },
-    "composer-runtime": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/composer-runtime/-/composer-runtime-0.16.2.tgz",
-      "integrity": "sha512-ODUEnt0BYg2S59+4OTEqkXN25PsBg35TcwpKazFscOZiHCdrm7Dc+W5afM4B0Z0fNDg0gal5Q9IMBnVJyLQnpQ==",
-      "dev": true,
-      "requires": {
-        "composer-common": "0.16.2",
-        "debug": "2.6.2",
-        "fast-json-patch": "1.1.8",
-        "lru-cache": "4.0.2",
-        "sha.js": "2.4.8",
-        "source-map": "0.5.6"
-      }
-    },
-    "composer-runtime-embedded": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/composer-runtime-embedded/-/composer-runtime-embedded-0.16.2.tgz",
-      "integrity": "sha512-xl7Kev4iHUp0cSZsm/iaCEyo2xH5UQ9Ob+A0WVh9V+QHhkVRvPy5L5XUuiUTG9E9j9Abfw99Xam9FcTxRnSBGg==",
-      "dev": true,
-      "requires": {
-        "composer-common": "0.16.2",
-        "composer-runtime": "0.16.2",
-        "composer-runtime-pouchdb": "0.16.2",
-        "debug": "2.6.2",
-        "istanbul-lib-instrument": "1.7.2",
-        "pouchdb-adapter-memory": "6.2.0",
-        "request": "2.81.0",
-        "uuid": "3.0.1"
+        "composer-common": "0.16.3",
+        "composer-runtime": "0.16.3",
+        "composer-runtime-embedded": "0.16.3"
       },
       "dependencies": {
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+        "composer-runtime": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/composer-runtime/-/composer-runtime-0.16.3.tgz",
+          "integrity": "sha512-yEZxvdt2W4lNgymO0B4yM3YQPzeXlyQMj66IJzEk82nlTSh6p53byg2Or5PCbsSOBh8fTsE5xsgRmjhMDyktRQ==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
+            "composer-common": "0.16.3",
+            "debug": "2.6.2",
+            "fast-json-patch": "1.1.8",
+            "lru-cache": "4.0.2",
+            "sha.js": "2.4.8",
+            "source-map": "0.5.6"
+          }
+        },
+        "composer-runtime-embedded": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/composer-runtime-embedded/-/composer-runtime-embedded-0.16.3.tgz",
+          "integrity": "sha512-q2DhvzP0NbDGRLkdwhsBNIsIjbIdGvTY6vRqMpXWlmvJpoKiDNSdEXVO3appzodgwhIqV50LbFK7F3xZ15zjmw==",
+          "dev": true,
+          "requires": {
+            "composer-common": "0.16.3",
+            "composer-runtime": "0.16.3",
+            "composer-runtime-pouchdb": "0.16.3",
+            "debug": "2.6.2",
+            "istanbul-lib-instrument": "1.7.2",
+            "pouchdb-adapter-memory": "6.2.0",
+            "request": "2.81.0",
             "uuid": "3.0.1"
           }
-        }
-      }
-    },
-    "composer-runtime-hlfv1": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/composer-runtime-hlfv1/-/composer-runtime-hlfv1-0.16.2.tgz",
-      "integrity": "sha512-TrkYXvW82QinqIK0PEir43t3YXF65Q0weXwSV4OZgopbTrAfjMckRl1sqhZOVtu930bsCFmxfxiv8hudAl0RSg==",
-      "dev": true
-    },
-    "composer-runtime-pouchdb": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/composer-runtime-pouchdb/-/composer-runtime-pouchdb-0.16.2.tgz",
-      "integrity": "sha512-KqO3zdAw/y8yN4QCltnQrnp7Walx/rp5852KcK1YttGgv6VwX0MIkxizNjMvju8/pOmJXAlfeylmrpWG+7k5mA==",
-      "dev": true,
-      "requires": {
-        "composer-common": "0.16.2",
-        "composer-runtime": "0.16.2",
-        "debug": "2.6.2",
-        "istanbul-lib-instrument": "1.7.2",
-        "pouchdb-collate": "6.2.0",
-        "pouchdb-core": "6.2.0",
-        "pouchdb-find": "6.2.0",
-        "request": "2.81.0",
-        "uuid": "3.0.1"
-      },
-      "dependencies": {
+        },
+        "composer-runtime-pouchdb": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/composer-runtime-pouchdb/-/composer-runtime-pouchdb-0.16.3.tgz",
+          "integrity": "sha512-nP/S6Z2upKJgaPI17BmJa+FADwWAMYQnQFqJJTLwLevGPsmHHXEdCXdVjiPrTi3WdG2JXPlH6eV3wywikHKT7A==",
+          "dev": true,
+          "requires": {
+            "composer-common": "0.16.3",
+            "composer-runtime": "0.16.3",
+            "debug": "2.6.2",
+            "istanbul-lib-instrument": "1.7.2",
+            "pouchdb-collate": "6.2.0",
+            "pouchdb-core": "6.2.0",
+            "pouchdb-find": "6.2.0",
+            "request": "2.81.0",
+            "uuid": "3.0.1"
+          }
+        },
         "request": {
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "isa-transfers-network",
   "version": "0.0.1",
   "description": "ISA Transfer Authority Network",
+  "engines": {
+    "node": ">= 8.9.4"
+  },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --recursive"
+    "test": "./node_modules/mocha/bin/mocha --recursive && ./node_modules/eslint/bin/eslint.js ."
   },
   "author": "Giuseppe Lobraico",
   "email": "g.lobraico@gmail.com",

--- a/queries.qry
+++ b/queries.qry
@@ -1,7 +1,7 @@
-query findISABySortCodeAndAccountNumber {
+query findISABySortCodeAndAccountReference {
   description: "Find the ISA with the given provider and sort code"
   statement:
       SELECT b2b.isa.transfers.ISA
-          WHERE (sortCode == _$sortCode AND accountNumber == _$accountNumber)
+          WHERE (sortCode == _$sortCode AND accountReference == _$accountReference)
           LIMIT 1
 }

--- a/test/isaTransfer.js
+++ b/test/isaTransfer.js
@@ -116,7 +116,7 @@ describe('#' + namespace, () => {
 
             transferRequest = factory.newResource(namespace, mainAssetType, 'TransferRequest_1');
             transferRequest.sortCode = '000000';
-            transferRequest.accountNumber = '1111111';
+            transferRequest.accountReference = 'REF0123456789';
             transferRequest.fiscalYear = 2017;
             transferRequest.amountRequested = 5000;
             transferRequest.state = 'CREATED';
@@ -128,7 +128,7 @@ describe('#' + namespace, () => {
         });
 
         describe('when there is no ISA account matching the request', () => {
-            it('rejects the requests', () => {
+            it('rejects the request', () => {
                 return businessNetworkConnection.getAssetRegistry(namespace + '.' + mainAssetType).then(registry => {
                     assetRegistry = registry;
                     return registry.add(transferRequest);
@@ -151,7 +151,7 @@ describe('#' + namespace, () => {
             beforeEach(() => {
                 isa = factory.newResource(namespace, 'ISA', 'ISA_1');
                 isa.sortCode = transferRequest.sortCode;
-                isa.accountNumber = transferRequest.accountNumber;
+                isa.accountReference = transferRequest.accountReference;
                 isa.type = transferRequest.type;
                 isa.fiscalYear = transferRequest.fiscalYear;
                 isa.balance = transferRequest.amountRequested;
@@ -165,14 +165,14 @@ describe('#' + namespace, () => {
                     isa.fiscalYear = 2016;
                 });
 
-                it('rejects the requests', () => {
+                it('rejects the request', () => {
                     return businessNetworkConnection.getAssetRegistry(namespace + '.ISA').then(registry => {
                         return registry.add(isa);
                     }).then(() => {
                         return businessNetworkConnection.getAssetRegistry(namespace + '.' + mainAssetType).then(registry => {
                             assetRegistry = registry;
                             return registry.add(transferRequest);
-                        })
+                        });
                     }).then(() => {
                         return businessNetworkConnection.getParticipantRegistry(namespace + '.Provider');
                     }).then(providerRegistry => {
@@ -193,14 +193,14 @@ describe('#' + namespace, () => {
                     isa.balance = 1;
                 });
 
-                it('rejects the requests', () => {
+                it('rejects the request', () => {
                     return businessNetworkConnection.getAssetRegistry(namespace + '.ISA').then(registry => {
                         return registry.add(isa);
                     }).then(() => {
                         return businessNetworkConnection.getAssetRegistry(namespace + '.' + mainAssetType).then(registry => {
                             assetRegistry = registry;
                             return registry.add(transferRequest);
-                        })
+                        });
                     }).then(() => {
                         return businessNetworkConnection.getParticipantRegistry(namespace + '.Provider');
                     }).then(providerRegistry => {
@@ -224,7 +224,7 @@ describe('#' + namespace, () => {
                         return businessNetworkConnection.getAssetRegistry(namespace + '.' + mainAssetType).then(registry => {
                             assetRegistry = registry;
                             return registry.add(transferRequest);
-                        })
+                        });
                     }).then(() => {
                         return businessNetworkConnection.getParticipantRegistry(namespace + '.Provider');
                     }).then(providerRegistry => {
@@ -259,7 +259,7 @@ describe('#' + namespace, () => {
 
             transferRequest = factory.newResource(namespace, mainAssetType, 'TransferRequest_1');
             transferRequest.sortCode = '000000';
-            transferRequest.accountNumber = '1111111';
+            transferRequest.accountReference = 'REF0123456789';
             transferRequest.fiscalYear = 2017;
             transferRequest.amountRequested = 5000;
             transferRequest.state = 'ACCEPTED';
@@ -268,7 +268,7 @@ describe('#' + namespace, () => {
 
             isa = factory.newResource(namespace, 'ISA', 'ISA_1');
             isa.sortCode = transferRequest.sortCode;
-            isa.accountNumber = transferRequest.accountNumber;
+            isa.accountReference = transferRequest.accountReference;
             isa.type = transferRequest.type;
             isa.fiscalYear = transferRequest.fiscalYear;
             isa.balance = transferRequest.amountRequested;
@@ -289,7 +289,7 @@ describe('#' + namespace, () => {
                 return businessNetworkConnection.getAssetRegistry(namespace + '.' + mainAssetType).then(registry => {
                     assetRegistry = registry;
                     return registry.add(transferRequest);
-                })
+                });
             }).then(() => {
                 return businessNetworkConnection.getParticipantRegistry(namespace + '.Provider');
             }).then(providerRegistry => {
@@ -324,7 +324,7 @@ describe('#' + namespace, () => {
 
             transferRequest = factory.newResource(namespace, mainAssetType, 'TransferRequest_1');
             transferRequest.sortCode = '000000';
-            transferRequest.accountNumber = '1111111';
+            transferRequest.accountReference = 'REF0123456789';
             transferRequest.fiscalYear = 2017;
             transferRequest.amountRequested = 5000;
             transferRequest.amountSent = 4000;
@@ -333,8 +333,8 @@ describe('#' + namespace, () => {
             transferRequest.recipient = factory.newRelationship(namespace, 'Provider', recipient.$identifier);
 
             destinationIsa = factory.newResource(namespace, 'ISA', 'ISA_2');
-            destinationIsa.sortCode = '888888'
-            destinationIsa.accountNumber = '9999999';
+            destinationIsa.sortCode = '888888';
+            destinationIsa.accountReference = '9999999';
             destinationIsa.type = 'Stock&Shares';
             destinationIsa.fiscalYear = 2017;
             destinationIsa.balance = 10000;
@@ -354,7 +354,7 @@ describe('#' + namespace, () => {
                 return businessNetworkConnection.getAssetRegistry(namespace + '.' + mainAssetType).then(registry => {
                     assetRegistry = registry;
                     return registry.add(transferRequest);
-                })
+                });
             }).then(() => {
                 return businessNetworkConnection.getParticipantRegistry(namespace + '.Provider');
             }).then(providerRegistry => {


### PR DESCRIPTION
Some ISA providers identify an ISA with a reference code instead of the traditional account number.

Plus, make the sort code optional.